### PR TITLE
When the list of '<items>' is empty hide listView.

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2187,6 +2187,12 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
             listView.setAdapter(adapter);
             // Set layout manager to position the items
             listView.setLayoutManager(new LinearLayoutManager(this));
+
+            if (section_items.size() == 0) {
+                listView.setVisibility(View.GONE);
+            } else {
+                listView.setVisibility(View.VISIBLE);
+            }
         } else {
             //ArrayList<JSONObject> old_section_items = adapter.getItems();
             adapter.updateItems(section_items);


### PR DESCRIPTION
The base listview that all the body items goes into
is a recycler sitting at the top of the view, even if
there's no items in it.  this means there's a (64dp?)
gap at the top of the screen where taps are ignored.

This fix hides the listview if the list size is zero,
and restores it if non-zero.

I have no idea what kind of test suite we can do here...but
I'd recommend it gets tested until it's silly.