### PR TITLE
Updated code for action $push.register to get actual token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Sentimental Versioning](http://sentimentalversioning.org/).
 
-## [2.0.0] Next Release
+## [2.0.0] Release
 
-This version is the current in development.
+
 
 ### Added
 
+- Hjson reading capability 
+
+- Upgraded to AndroidX and better performance for Glide implementation
+
+- onBackPressed avoiding closing the app on Back button press
+
 ### Changed
+
+- Complete implementation for Calendar Demo
 
 - Minimum Android version bumped to `6.0`.
 
@@ -22,7 +30,7 @@ This version is the current in development.
 
 - Fixed `build.gradle` for Android Studio `v3.2.1`. By [@CydeSwype](https://github.com/Jasonette/JASONETTE-Android/commits?author=CydeSwype).
 
--  Fixed text zoom issue in `Webview` by [@naei](https://github.com/naei).
+- Fixed text zoom issue in `Webview` by [@naei](https://github.com/naei).
 
 ### Updated
 

--- a/app/src/main/java/com/jasonette/seed/Action/JasonPushAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonPushAction.java
@@ -3,12 +3,17 @@ package com.jasonette.seed.Action;
 import android.content.Context;
 import android.util.Log;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Helper.JasonHelper;
 import com.jasonette.seed.Launcher.Launcher;
 
 import org.json.JSONObject;
+
+import androidx.annotation.NonNull;
 
 // Unlike APN which requires manual registration, FCM automatically registers push upon app launch.
 // As a result, $push.register can behave in two different ways:
@@ -17,21 +22,35 @@ import org.json.JSONObject;
 
 public class JasonPushAction {
     public void register(final JSONObject action, JSONObject data, final JSONObject event, Context context) {
-        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-        if(refreshedToken != null){
-            // Token exists => already registered => Immediately trigger $push.onregister
-            try {
-                JSONObject response = new JSONObject();
-                JSONObject payload = new JSONObject();
-                payload.put("token", refreshedToken);
-                response.put("$jason", payload);
-                ((JasonViewActivity)Launcher.getCurrentContext()).simple_trigger("$push.onregister", response, Launcher.getCurrentContext());
-            } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
-            }
-        } else {
-            // Token doesn't exist => ignore => JasonPushRegisterService will take care of $push.onregister
-        }
+
+        FirebaseInstanceId.getInstance().getInstanceId()
+                .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+                    @Override
+                    public void onComplete(@NonNull Task<InstanceIdResult> task) {
+                        if (!task.isSuccessful()) {
+                            Log.w("Instance", "getInstanceId failed", task.getException());
+                            return;
+                        }
+                        // Get new Instance ID token
+                        String refreshedToken = task.getResult().getToken();
+                        if(refreshedToken != null){
+                            // Token exists => already registered => Immediately trigger $push.onregister
+                            try {
+                                JSONObject response = new JSONObject();
+                                JSONObject payload = new JSONObject();
+                                payload.put("token", refreshedToken);
+                                response.put("$jason", payload);
+                                ((JasonViewActivity)Launcher.getCurrentContext()).simple_trigger("$push.onregister", response, Launcher.getCurrentContext());
+                            } catch (Exception e) {
+                                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                            }
+                        } else {
+                            // Token doesn't exist => ignore => JasonPushRegisterService will take care of $push.onregister
+                        }
+                    }
+                });
+
+
         JasonHelper.next("success", action, data, event, context);
     }
 }


### PR DESCRIPTION
Currently you can get device token only once when it firstly generated. This fix returning ability to read token by triggering action $push.register and it will be returned to $push.onregister
```
"actions": {
                "$load": {
                    "type": "$push.register"
                },
                "$push.onregister": {
                    "type": "$util.alert",
                    "options": {
                        "title": "Token received",
                        "description": "token {{$jason.token}}"
                    }
                }
            }
```