### PR TITLE
Update to use same builder object for network request

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
@@ -129,7 +129,6 @@ public class JasonNetworkAction {
                             mediaType = MediaType.parse(content_type);
                             d = Base64.decode(options.getString("data"), Base64.DEFAULT);
                         }
-                        // Request.Builder requestBuilder = new Request.Builder();
 
                         request = builder
                                 .url(url)

--- a/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
@@ -129,9 +129,9 @@ public class JasonNetworkAction {
                             mediaType = MediaType.parse(content_type);
                             d = Base64.decode(options.getString("data"), Base64.DEFAULT);
                         }
-                        Request.Builder requestBuilder = new Request.Builder();
+                        // Request.Builder requestBuilder = new Request.Builder();
 
-                        request = requestBuilder
+                        request = builder
                                 .url(url)
                                 .method(method, RequestBody.create(mediaType, d))
                                 .build();


### PR DESCRIPTION
When building request object for network request, if the header contain "content_type", the current codes create new "requestBuilder" object instead of using existing "builder" object, and resulting the request to loose all the other headers/session headers that might exist. The update is to reuse existing "builder" object instead.